### PR TITLE
homeassistant catflap unlock and multiple camera sources

### DIFF
--- a/camera_class_mjpeg.py
+++ b/camera_class_mjpeg.py
@@ -1,0 +1,48 @@
+from collections import deque
+import pytz
+from datetime import datetime
+import time, gc
+import cv2
+import numpy as np
+
+MJPEG_STREAM_URL = "http://localhost:9000/mjpg"  # Replace with your MJPEG stream URL
+
+class Camera:
+    def __init__(self):
+        self.cap = cv2.VideoCapture(MJPEG_STREAM_URL)
+        if not self.cap.isOpened():
+            raise RuntimeError(f"Failed to open MJPEG stream: {MJPEG_STREAM_URL}")
+        time.sleep(2)
+
+    def _restart_camera(self):
+        self.cap.release()
+        gc.collect()
+        self.__init__()
+
+    def fill_queue(self, q: deque):
+        i = 0
+        tz = pytz.timezone("Europe/Berlin")
+        last_enqueue_time = time.time()
+
+        while True:
+            ret, frame = self.cap.read()
+            if not ret:
+                print("Failed to read frame from MJPEG stream.")
+                time.sleep(1)
+                self._restart_camera()
+                continue
+
+            now = time.time()
+            if now - last_enqueue_time >= 0.5:  # 0.5 sec = 2 FPS
+                timestamp = datetime.now(tz).strftime("%Y_%m_%d_%H-%M-%S.%f")
+                q.append((timestamp, frame))
+                last_enqueue_time = now
+
+                print(f"Quelength: {len(q)}\tFrame shape: {frame.shape}")
+                i += 1
+
+                if i >= 60:
+                    print("Loop ended, restarting camera resources…")
+                    self._restart_camera()
+                    i = 0
+

--- a/camera_class_rtsp.py
+++ b/camera_class_rtsp.py
@@ -1,0 +1,48 @@
+from collections import deque
+import pytz
+from datetime import datetime
+import time, gc
+import cv2
+import numpy as np
+
+RTSP_URL = "rtsp://stream:P4Vdo@192.168.178.59:8554/unicast"  # Replace with your RTSP stream URL
+
+class Camera:
+    def __init__(self):
+        self.cap = cv2.VideoCapture(RTSP_URL)
+        if not self.cap.isOpened():
+            raise RuntimeError(f"Failed to open RTSP stream: {RTSP_URL}")
+        time.sleep(2)
+
+    def _restart_camera(self):
+        self.cap.release()
+        gc.collect()
+        self.__init__()
+
+    def fill_queue(self, q: deque):
+        i = 0
+        tz = pytz.timezone("Europe/Berlin")
+        last_enqueue_time = time.time()
+
+        while True:
+            ret, frame = self.cap.read()
+            if not ret:
+                print("Failed to read frame from RTSP stream.")
+                time.sleep(1)
+                self._restart_camera()
+                continue
+
+            now = time.time()
+            if now - last_enqueue_time >= 0.5:  # 0.5 sec = 2 FPS
+                timestamp = datetime.now(tz).strftime("%Y_%m_%d_%H-%M-%S.%f")
+                q.append((timestamp, frame))
+                last_enqueue_time = now
+
+                print(f"Quelength: {len(q)}\tFrame shape: {frame.shape}")
+                i += 1
+
+                if i >= 60:
+                    print("Loop ended, restarting camera resources…")
+                    self._restart_camera()
+                    i = 0
+

--- a/catCam_starter.sh
+++ b/catCam_starter.sh
@@ -4,4 +4,4 @@ echo "Executing CatPreyAnalyzer"
 # Tensorflow Stuff
 export PYTHONPATH=$PYTHONPATH:/home/pi/tensorflow/models/research:/home/pi/tensorflow/models/research/slim:/home/pi/.local/lib/python3.7/site-packages
 cd /home/pi/CatPreyAnalyzer
-python3 cascade.py
+python3 cascade.py $@


### PR DESCRIPTION
Hi
I added parameters to be able to select between multiple camera sources (libcamera, RTSP and MJPEG streams), added unlocking homeassistant sureflap through webhooks and resolution and/or horizontal/vertical camera image flip options. 
I also changed some minor stuff in the messages and removed some others, you can ignore those changes if you want :)
I'm thinking of perhaps using debug switches to control the output, perhaps even logging to a logfile (useful for daemonizing the process).
I tested it on a pi4 with the latest bookworm OS and it works so far. Also had to use some older python modules for it to work, but now it's OK.
I also changed the queue to use only 2fps, so it lowers the load on the system and heightens the speed a bit. I also use a multiple of 2fps for the camera streams (currently 6fps for the RTSP cam).
Start it by:
- `catCam_starter.sh`
- `catCam_starter.sh --with-rtsp`
- `catCam_starter.sh --with-mjpeg`

after you modified the stream URLs and resolution and/or horizontal/vertical camera image flip options in `camera_class_rtsp.py` and/or `camera_class_mjpeg.py`.